### PR TITLE
fix(consumer): detect closed errors/messages channels in offsetConsumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Please choose versions by [Semantic Versioning](http://semver.org/).
 * MINOR version when you add functionality in a backwards-compatible manner, and
 * PATCH version when you make backwards-compatible bug fixes.
 
+## v1.22.15
+
+- fix(consumer): detect closed errors/messages channels in offsetConsumer.consumeMessages and return an explicit error instead of spinning on nil deliveries
+
 ## v1.22.14
 
 - bump github.com/IBM/sarama v1.48.0 -> v1.48.1

--- a/kafka_consumer-offset.go
+++ b/kafka_consumer-offset.go
@@ -259,6 +259,8 @@ func (c *offsetConsumer) Consume(ctx context.Context) error {
 }
 
 // consume
+//
+//nolint:gocognit // Channel-close detection adds branches; refactoring would reduce readability
 func (c *offsetConsumer) consumeMessages(
 	ctx context.Context,
 	consumePartition sarama.PartitionConsumer,
@@ -268,11 +270,17 @@ func (c *offsetConsumer) consumeMessages(
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
-	case err := <-consumePartition.Errors():
+	case err, ok := <-consumePartition.Errors():
+		if !ok {
+			return nil, errors.Errorf(ctx, "partition consumer errors channel closed")
+		}
 		if err := c.errorHandler.HandleError(err); err != nil {
 			return nil, errors.Wrapf(ctx, err, "parition consumer returns error")
 		}
-	case msg := <-consumePartition.Messages():
+	case msg, ok := <-consumePartition.Messages():
+		if !ok {
+			return nil, errors.Errorf(ctx, "partition consumer messages channel closed")
+		}
 		result = append(result, msg)
 	}
 
@@ -284,11 +292,17 @@ func (c *offsetConsumer) consumeMessages(
 		select {
 		case <-ctx.Done():
 			return nil, ctx.Err()
-		case err := <-consumePartition.Errors():
+		case err, ok := <-consumePartition.Errors():
+			if !ok {
+				return nil, errors.Errorf(ctx, "partition consumer errors channel closed")
+			}
 			if err := c.errorHandler.HandleError(err); err != nil {
 				return nil, errors.Wrapf(ctx, err, "parition consumer returns error")
 			}
-		case msg := <-consumePartition.Messages():
+		case msg, ok := <-consumePartition.Messages():
+			if !ok {
+				return nil, errors.Errorf(ctx, "partition consumer messages channel closed")
+			}
 			result = append(result, msg)
 		default:
 			glog.V(4).Infof("no more messages => return %d messages", len(result))

--- a/kafka_consumer-offset_internal_test.go
+++ b/kafka_consumer-offset_internal_test.go
@@ -1,0 +1,146 @@
+// Copyright (c) 2026 Benjamin Borbe All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package kafka
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/IBM/sarama"
+)
+
+// fakePartitionConsumer is a minimal in-package fake implementing
+// sarama.PartitionConsumer for tests that exercise channel-close behaviour.
+type fakePartitionConsumer struct {
+	messages chan *sarama.ConsumerMessage
+	errors   chan *sarama.ConsumerError
+}
+
+func (f *fakePartitionConsumer) AsyncClose() {}
+
+func (f *fakePartitionConsumer) Close() error { return nil }
+
+func (f *fakePartitionConsumer) Messages() <-chan *sarama.ConsumerMessage { return f.messages }
+
+func (f *fakePartitionConsumer) Errors() <-chan *sarama.ConsumerError { return f.errors }
+
+func (f *fakePartitionConsumer) HighWaterMarkOffset() int64 { return 0 }
+
+func (f *fakePartitionConsumer) Pause() {}
+
+func (f *fakePartitionConsumer) Resume() {}
+
+func (f *fakePartitionConsumer) IsPaused() bool { return false }
+
+func newOffsetConsumerForTest(batchSize int) *offsetConsumer {
+	return &offsetConsumer{
+		batchSize:    BatchSize(batchSize),
+		errorHandler: NewConsumerErrorHandler(NewMetrics()),
+	}
+}
+
+func TestConsumeMessages_OuterErrorsChannelClosed(t *testing.T) {
+	pc := &fakePartitionConsumer{}
+	errCh := make(chan *sarama.ConsumerError)
+	close(errCh)
+	pc.errors = errCh
+
+	result, err := newOffsetConsumerForTest(1).consumeMessages(context.Background(), pc)
+
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "errors channel closed") {
+		t.Errorf("expected 'errors channel closed' in error, got: %v", err)
+	}
+	if result != nil {
+		t.Errorf("expected nil result, got %v", result)
+	}
+}
+
+func TestConsumeMessages_OuterMessagesChannelClosed(t *testing.T) {
+	pc := &fakePartitionConsumer{}
+	msgCh := make(chan *sarama.ConsumerMessage)
+	close(msgCh)
+	pc.messages = msgCh
+
+	result, err := newOffsetConsumerForTest(1).consumeMessages(context.Background(), pc)
+
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "messages channel closed") {
+		t.Errorf("expected 'messages channel closed' in error, got: %v", err)
+	}
+	if result != nil {
+		t.Errorf("expected nil result, got %v", result)
+	}
+}
+
+func TestConsumeMessages_InnerErrorsChannelClosed(t *testing.T) {
+	pc := &fakePartitionConsumer{}
+	msgCh := make(chan *sarama.ConsumerMessage, 1)
+	msgCh <- &sarama.ConsumerMessage{Topic: "t", Partition: 0, Offset: 0}
+	pc.messages = msgCh
+
+	errCh := make(chan *sarama.ConsumerError)
+	close(errCh)
+	pc.errors = errCh
+
+	_, err := newOffsetConsumerForTest(5).consumeMessages(context.Background(), pc)
+
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "errors channel closed") {
+		t.Errorf("expected 'errors channel closed' in error, got: %v", err)
+	}
+}
+
+func TestConsumeMessages_InnerMessagesChannelClosed(t *testing.T) {
+	pc := &fakePartitionConsumer{}
+	msgCh := make(chan *sarama.ConsumerMessage, 1)
+	msgCh <- &sarama.ConsumerMessage{Topic: "t", Partition: 0, Offset: 0}
+	close(msgCh)
+	pc.messages = msgCh
+
+	_, err := newOffsetConsumerForTest(5).consumeMessages(context.Background(), pc)
+
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "messages channel closed") {
+		t.Errorf("expected 'messages channel closed' in error, got: %v", err)
+	}
+}
+
+func TestConsumeMessages_ContextCancelled(t *testing.T) {
+	pc := &fakePartitionConsumer{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := newOffsetConsumerForTest(1).consumeMessages(ctx, pc)
+
+	if err != context.Canceled {
+		t.Errorf("expected context.Canceled, got: %v", err)
+	}
+}
+
+func TestConsumeMessages_SingleMessageThenDefault(t *testing.T) {
+	pc := &fakePartitionConsumer{}
+	msgCh := make(chan *sarama.ConsumerMessage, 1)
+	msgCh <- &sarama.ConsumerMessage{Topic: "t", Partition: 0, Offset: 0}
+	pc.messages = msgCh
+
+	result, err := newOffsetConsumerForTest(5).consumeMessages(context.Background(), pc)
+
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if len(result) != 1 {
+		t.Errorf("expected 1 message, got %d", len(result))
+	}
+}


### PR DESCRIPTION
## Summary

Adds `, ok` channel-close detection to `offsetConsumer.consumeMessages` (both selects, both channels). On closed `Errors()` or `Messages()` channel, returns an explicit error so the consume goroutine exits cleanly instead of busy-looping on nil deliveries or panicking on `msg.Topic` deref.

## Context

Found during root-cause investigation of the 2026-05-10 21:21:45 UTC Kafka EOF incident that left 10+ trading consumer pods running but not consuming for hours. The incident itself was a real error delivered on an *open* `Errors()` channel (already handled), but the investigation surfaced a **separate latent bug**: if sarama ever *closes* either channel (e.g., after `AsyncClose`, partition consumer reassignment, or future sarama versions), our code hits an instant-fire spin / nil-deref path.

Two failure modes prevented:

- **Outer blocking select**: closed channel fires once with nil → `HandleError(nil).err.Topic` → nil pointer panic
- **Inner non-blocking select** (in `for { select { ... default: } }`): closed channel fires *every iteration* without blocking → tight loop alternating between `HandleError(nil)` panic and `append(result, nil)` until caller dereferences a nil message in the parent goroutine

## Changes

- `kafka_consumer-offset.go` — `case err, ok := <-Errors()` and `case msg, ok := <-Messages()` in both selects, with `if !ok { return nil, errors.Errorf(ctx, "...") }`
- `kafka_consumer-offset_internal_test.go` — new `package kafka` test file (uses plain `testing.T` to avoid Ginkgo's "only one RunSpecs per binary" constraint, and an in-package fake to avoid the mocks→kafka import cycle). Covers all 4 channel-close branches plus context-cancel and happy-path baselines.
- `CHANGELOG.md` — v1.22.15 entry

## Test plan

- [x] `make precommit` passes (format, generate, test, check, addlicense)
- [x] All 6 new test cases pass
- [x] Existing test suite unaffected