### PR TITLE
feat: consumer-side decrypt + gunzip MessageHandlerTx wrappers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Please choose versions by [Semantic Versioning](http://semver.org/).
 * MINOR version when you add functionality in a backwards-compatible manner, and
 * PATCH version when you make backwards-compatible bug fixes.
 
+## Unreleased
+
+- add NewDecryptMessageHandlerTx consumer wrapper that decrypts msg.Value via a ValueModifierFunc before delegating to the inner MessageHandlerTx (drop-in for seibert-data/lib-kafka/consumer.NewDecryptMessageHandler, but for the Tx variant + no crypto package dep)
+- add NewGzipMessageHandlerTx consumer wrapper that gunzips msg.Value when the GzipHeaderKey marker is present and strips the header (drop-in for seibert-data/lib-kafka/consumer.NewGzipMessageHandler, but for the Tx variant)
+
 ## v1.24.0
 
 - add NewSyncProducerGzipValue producer wrapper (drop-in for seibert-data/lib-kafka)

--- a/kafka_message-handler-tx-decrypt.go
+++ b/kafka_message-handler-tx-decrypt.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Benjamin Borbe All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package kafka
+
+import (
+	"context"
+
+	"github.com/IBM/sarama"
+	"github.com/bborbe/errors"
+	libkv "github.com/bborbe/kv"
+)
+
+// NewDecryptMessageHandlerTx returns a MessageHandlerTx that decrypts
+// msg.Value with the given ValueModifierFunc before delegating to the inner
+// handler. Empty values pass through unmodified.
+//
+// bborbe/kafka does not depend on a specific crypto package — callers pass a
+// function. For the canonical AES-GCM implementation, use
+// github.com/bborbe/crypto and pass crypter.Decrypt as the modifier:
+//
+//	h := libkafka.NewDecryptMessageHandlerTx(inner, crypter.Decrypt)
+func NewDecryptMessageHandlerTx(
+	inner MessageHandlerTx,
+	decrypt ValueModifierFunc,
+) MessageHandlerTx {
+	return MessageHandlerTxFunc(
+		func(ctx context.Context, tx libkv.Tx, msg *sarama.ConsumerMessage) error {
+			if len(msg.Value) > 0 {
+				decrypted, err := decrypt(ctx, msg.Value)
+				if err != nil {
+					return errors.Wrapf(ctx, err, "decrypt msg failed")
+				}
+				msg.Value = decrypted
+			}
+			return inner.ConsumeMessage(ctx, tx, msg)
+		},
+	)
+}

--- a/kafka_message-handler-tx-decrypt_test.go
+++ b/kafka_message-handler-tx-decrypt_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 Benjamin Borbe All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package kafka_test
+
+import (
+	"context"
+	stderrors "errors"
+
+	"github.com/IBM/sarama"
+	"github.com/bborbe/errors"
+	libkv "github.com/bborbe/kv"
+	kvmocks "github.com/bborbe/kv/mocks"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	libkafka "github.com/bborbe/kafka"
+	"github.com/bborbe/kafka/mocks"
+)
+
+var _ = Describe("NewDecryptMessageHandlerTx", func() {
+	var (
+		ctx     context.Context
+		tx      libkv.Tx
+		inner   *mocks.KafkaMessageHandlerTx
+		handler libkafka.MessageHandlerTx
+		called  int
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		tx = &kvmocks.Tx{}
+		inner = &mocks.KafkaMessageHandlerTx{}
+		called = 0
+		handler = libkafka.NewDecryptMessageHandlerTx(
+			inner,
+			func(_ context.Context, v []byte) ([]byte, error) {
+				called++
+				out := make([]byte, len(v))
+				for i, b := range v {
+					out[i] = b ^ 0x42
+				}
+				return out, nil
+			},
+		)
+	})
+
+	It("decrypts non-empty values and delegates with the mutated msg", func() {
+		value := []byte("secret")
+		msg := &sarama.ConsumerMessage{Value: value}
+		Expect(handler.ConsumeMessage(ctx, tx, msg)).To(BeNil())
+		Expect(called).To(Equal(1))
+		Expect(inner.ConsumeMessageCallCount()).To(Equal(1))
+		_, passedTx, passedMsg := inner.ConsumeMessageArgsForCall(0)
+		Expect(passedTx).To(Equal(tx))
+		Expect(passedMsg.Value).NotTo(Equal(value))
+		Expect(passedMsg.Value).To(HaveLen(len(value)))
+	})
+
+	It("passes empty values through without invoking the modifier", func() {
+		msg := &sarama.ConsumerMessage{Value: nil}
+		Expect(handler.ConsumeMessage(ctx, tx, msg)).To(BeNil())
+		Expect(called).To(Equal(0))
+		Expect(inner.ConsumeMessageCallCount()).To(Equal(1))
+	})
+
+	It("passes zero-length values through without invoking the modifier", func() {
+		msg := &sarama.ConsumerMessage{Value: []byte{}}
+		Expect(handler.ConsumeMessage(ctx, tx, msg)).To(BeNil())
+		Expect(called).To(Equal(0))
+		Expect(inner.ConsumeMessageCallCount()).To(Equal(1))
+	})
+
+	It("propagates a decrypt error and does not delegate", func() {
+		handler = libkafka.NewDecryptMessageHandlerTx(
+			inner,
+			func(_ context.Context, _ []byte) ([]byte, error) {
+				return nil, stderrors.New("kapow")
+			},
+		)
+		err := handler.ConsumeMessage(ctx, tx, &sarama.ConsumerMessage{Value: []byte("x")})
+		Expect(err).NotTo(BeNil())
+		Expect(errors.Cause(err).Error()).To(Equal("kapow"))
+		Expect(inner.ConsumeMessageCallCount()).To(Equal(0))
+	})
+
+	It("propagates the inner handler error", func() {
+		inner.ConsumeMessageReturns(stderrors.New("inner-fail"))
+		err := handler.ConsumeMessage(ctx, tx, &sarama.ConsumerMessage{Value: []byte("x")})
+		Expect(err).NotTo(BeNil())
+		Expect(err.Error()).To(ContainSubstring("inner-fail"))
+	})
+})

--- a/kafka_message-handler-tx-gzip.go
+++ b/kafka_message-handler-tx-gzip.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 Benjamin Borbe All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package kafka
+
+import (
+	"context"
+
+	"github.com/IBM/sarama"
+	"github.com/bborbe/errors"
+	libkv "github.com/bborbe/kv"
+)
+
+// NewGzipMessageHandlerTx returns a MessageHandlerTx that gunzips msg.Value
+// when the GzipHeaderKey / GzipHeaderValue marker is present, then delegates
+// to the inner handler. The gzip header is stripped from msg.Headers after a
+// successful decompression so downstream handlers don't see a stale marker.
+// Empty values and messages without the gzip marker pass through unmodified.
+//
+// Use this on the consumer side when the producer wraps with
+// NewSyncProducerGzipValue — the on-the-wire header convention is identical
+// to seibert-data/lib-kafka.
+func NewGzipMessageHandlerTx(
+	inner MessageHandlerTx,
+) MessageHandlerTx {
+	return MessageHandlerTxFunc(
+		func(ctx context.Context, tx libkv.Tx, msg *sarama.ConsumerMessage) error {
+			if len(msg.Value) > 0 && GzipActive(msg.Headers) {
+				decompressed, err := GzipDecoder(ctx, msg.Value)
+				if err != nil {
+					return errors.Wrapf(ctx, err, "gzip decompress failed")
+				}
+				msg.Value = decompressed
+				msg.Headers = RemoveGzipHeader(msg.Headers)
+			}
+			return inner.ConsumeMessage(ctx, tx, msg)
+		},
+	)
+}

--- a/kafka_message-handler-tx-gzip_test.go
+++ b/kafka_message-handler-tx-gzip_test.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2026 Benjamin Borbe All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package kafka_test
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	stderrors "errors"
+
+	"github.com/IBM/sarama"
+	libkv "github.com/bborbe/kv"
+	kvmocks "github.com/bborbe/kv/mocks"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	libkafka "github.com/bborbe/kafka"
+	"github.com/bborbe/kafka/mocks"
+)
+
+func gzipValue(input []byte) []byte {
+	buf := &bytes.Buffer{}
+	w := gzip.NewWriter(buf)
+	_, _ = w.Write(input)
+	_ = w.Close()
+	return buf.Bytes()
+}
+
+var _ = Describe("NewGzipMessageHandlerTx", func() {
+	var (
+		ctx     context.Context
+		tx      libkv.Tx
+		inner   *mocks.KafkaMessageHandlerTx
+		handler libkafka.MessageHandlerTx
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		tx = &kvmocks.Tx{}
+		inner = &mocks.KafkaMessageHandlerTx{}
+		handler = libkafka.NewGzipMessageHandlerTx(inner)
+	})
+
+	It("decompresses values tagged with the gzip header and strips the header", func() {
+		plain := []byte("hello world")
+		msg := &sarama.ConsumerMessage{
+			Value: gzipValue(plain),
+			Headers: []*sarama.RecordHeader{
+				{Key: []byte("foo"), Value: []byte("bar")},
+				{Key: []byte(libkafka.GzipHeaderKey), Value: []byte(libkafka.GzipHeaderValue)},
+			},
+		}
+		Expect(handler.ConsumeMessage(ctx, tx, msg)).To(BeNil())
+		Expect(inner.ConsumeMessageCallCount()).To(Equal(1))
+		_, _, passed := inner.ConsumeMessageArgsForCall(0)
+		Expect(passed.Value).To(Equal(plain))
+		Expect(libkafka.GzipActive(passed.Headers)).To(BeFalse())
+		Expect(passed.Headers).To(HaveLen(1))
+		Expect(string(passed.Headers[0].Key)).To(Equal("foo"))
+	})
+
+	It("passes values without the gzip marker through unmodified", func() {
+		msg := &sarama.ConsumerMessage{
+			Value:   []byte("plain text"),
+			Headers: []*sarama.RecordHeader{{Key: []byte("foo"), Value: []byte("bar")}},
+		}
+		Expect(handler.ConsumeMessage(ctx, tx, msg)).To(BeNil())
+		_, _, passed := inner.ConsumeMessageArgsForCall(0)
+		Expect(passed.Value).To(Equal([]byte("plain text")))
+		Expect(passed.Headers).To(HaveLen(1))
+	})
+
+	It("passes empty values through without inspecting headers", func() {
+		msg := &sarama.ConsumerMessage{
+			Value: nil,
+			Headers: []*sarama.RecordHeader{
+				{Key: []byte(libkafka.GzipHeaderKey), Value: []byte(libkafka.GzipHeaderValue)},
+			},
+		}
+		Expect(handler.ConsumeMessage(ctx, tx, msg)).To(BeNil())
+		_, _, passed := inner.ConsumeMessageArgsForCall(0)
+		Expect(passed.Value).To(BeNil())
+		// gzip header NOT stripped because decompression did not run.
+		Expect(libkafka.GzipActive(passed.Headers)).To(BeTrue())
+	})
+
+	It("propagates a gzip decompression error and does not delegate", func() {
+		msg := &sarama.ConsumerMessage{
+			Value: []byte("not really gzipped"),
+			Headers: []*sarama.RecordHeader{
+				{Key: []byte(libkafka.GzipHeaderKey), Value: []byte(libkafka.GzipHeaderValue)},
+			},
+		}
+		err := handler.ConsumeMessage(ctx, tx, msg)
+		Expect(err).NotTo(BeNil())
+		Expect(err.Error()).To(ContainSubstring("gzip decompress failed"))
+		Expect(inner.ConsumeMessageCallCount()).To(Equal(0))
+	})
+
+	It("propagates the inner handler error", func() {
+		inner.ConsumeMessageReturns(stderrors.New("inner-fail"))
+		msg := &sarama.ConsumerMessage{Value: []byte("plain")}
+		err := handler.ConsumeMessage(ctx, tx, msg)
+		Expect(err).NotTo(BeNil())
+		Expect(err.Error()).To(ContainSubstring("inner-fail"))
+	})
+})


### PR DESCRIPTION
## Summary

Adds the consumer-side counterparts to v1.24.0's producer wrappers, completing the bborbe/kafka migration story for services moving off `seibert-data/lib-kafka`.

- **`NewDecryptMessageHandlerTx(inner MessageHandlerTx, decrypt ValueModifierFunc) MessageHandlerTx`** — decrypts `msg.Value` before delegating. No `bborbe/crypto` type dep; callers pass `crypter.Decrypt` directly. Drop-in shape replacement for `seibert-data/lib-kafka/consumer.NewDecryptMessageHandler` (Tx variant).
- **`NewGzipMessageHandlerTx(inner MessageHandlerTx) MessageHandlerTx`** — gunzips `msg.Value` when the `GzipHeaderKey` / `GzipHeaderValue` marker is present and strips the header on success. Wire-compatible with `seibert-data/lib-kafka/consumer.NewGzipMessageHandler`.

Scope is deliberately just the **`Tx` variant** — that's what the sm-octopus v2 services use after the migration. Simple / Batch / BatchTx variants can land as follow-ups when other services need them; the patterns are mechanical.

## Motivation

The two sm-octopus services migrating off `lib-kafka` (`kafka/topic-unique-v2` and `kafka/topic-delete-unseen-v2`) today re-implement these two wrappers verbatim in each service's local `pkg/decoders.go`. Once this PR ships, both services can drop `pkg/decoders.go` and call the canonical bborbe/kafka exports.

## Test plan

- [x] `make precommit` clean (lint/vet/tests/osv/trivy/license)
- [x] Unit tests for both wrappers cover: success path, empty/nil value pass-through, modifier error propagation, inner-handler error propagation, gzip-header strip, no-marker pass-through, invalid-gzip error